### PR TITLE
fix: New version polyline naming

### DIFF
--- a/src/objects/TiledPrimitives.ts
+++ b/src/objects/TiledPrimitives.ts
@@ -167,7 +167,7 @@ export function BuildPrimitive( meta: ITiledObject ): ITiledPtimitive | undefine
 			break;
 		}
 		case TiledObjectType.POLYLINE: {
-			const points = meta.polygon!;
+			const points = meta.polyline!;
 			const poses = points.map(p => {
 				return new Point(p.x + meta.x, p.y + meta.y);
 			});


### PR DESCRIPTION
Small fix. I think naming of polylines was changed in one of the lates versions of Tiled.
I had a crash when tried to load map wwith polyline from latest Tiled.